### PR TITLE
Fix - threshold 1 multisigs

### DIFF
--- a/src/mappings/types.ts
+++ b/src/mappings/types.ts
@@ -10,6 +10,13 @@ export interface MultisigArgs {
   };
 }
 
+export interface MultisigThreshold1Args {
+  args: {
+    other_signatories: string[];
+    call: unknown
+  }
+}
+
 export interface CancelMultisigArgs {
   args: {
     threshold: number;


### PR DESCRIPTION
Destructuring to `MultisigArgs` is invalid in case of threhsold 1 multisigs as they use another call. Bug resulted in threshold 0 as well as wrong multisig addresses being recorded