### PR TITLE
fix: rejected operation whon't delete call data

### DIFF
--- a/src/mappings/handlers/multisigCallHandler.ts
+++ b/src/mappings/handlers/multisigCallHandler.ts
@@ -89,16 +89,16 @@ async function getTransaction(visitedCall: VisitedCall): Promise<MultisigOperati
   const newOperation = await MultisigOperation.create({
     ...existingOperation,
     id: operationId,
-    section,
-    method,
-    chainId,
-    callData,
-    callHash,
+    section: section,
+    method: method,
+    chainId: chainId,
+    callData: callData,
+    callHash: callHash,
     status: existingOperation?.status || OperationStatus.pending,
     accountId: multisigAccountId,
     depositor: u8aToHex(decodeAddress(visitedCall.origin)),
-    blockCreated,
-    indexCreated,
+    blockCreated: blockCreated,
+    indexCreated: indexCreated,
     timestamp: timestamp(visitedCall.extrinsic.block)
   });
 

--- a/src/mappings/handlers/multisigCallHandler.ts
+++ b/src/mappings/handlers/multisigCallHandler.ts
@@ -81,13 +81,18 @@ async function getTransaction(visitedCall: VisitedCall): Promise<MultisigOperati
 
   const operationId = generateOperationId(callHash, multisigAccountId, blockCreated, indexCreated);
 
+  // For cancelAsMulti, preserve existing operation data if call is null
+  const section = call?.section || existingOperation?.section;
+  const method = call?.method || existingOperation?.method;
+  const callData = call?.toHex() || existingOperation?.callData;
+
   const newOperation = await MultisigOperation.create({
     ...existingOperation,
     id: operationId,
-    section: call?.section,
-    method: call?.method,
+    section,
+    method,
     chainId,
-    callData: call?.toHex(),
+    callData,
     callHash,
     status: existingOperation?.status || OperationStatus.pending,
     accountId: multisigAccountId,


### PR DESCRIPTION
Found a problem with rejected operations, call_data, method and section is set to null, when cancelAsMulti event processed

Before:
<img width="1512" alt="Screenshot 2025-07-10 at 09 49 12" src="https://github.com/user-attachments/assets/81c14014-17de-4c25-96b5-29eeb9185100" />


After:
<img width="1465" alt="Screenshot 2025-07-10 at 09 48 54" src="https://github.com/user-attachments/assets/49816ee0-2beb-498a-a061-f6e6b9e87864" />
