### PR TITLE
Fix/westend_ah_migration

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -64,7 +64,7 @@ enum OperationStatus {
 
 type MultisigOperation @entity {
   id: ID!
-  status: OperationStatus!
+  status: OperationStatus! @index
   chainId: String!
   accountId: String! @index
   section: String


### PR DESCRIPTION
Fixed error:

```sh
2025-10-01T10:07:02.967Z <BlockDispatcherService> ERROR Failed to index block at height 11720095 handleMultisigExecutedEvent(Error: Operation not found for call hash: 0xb82e785850266c370345245630424894df164b66e5c07a4da562f9b24cb56996 on block: 26048347 index: 2 multisig account id: 0xf91ceb7ea87f99d842d530f7df106e185a6a352a170857d9062e2368c4a1ee6d
    at gu (/project/dist/index.js:6:435697)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.Mu (/project/dist/index.js:6:437010)) Error: Operation not found for call hash: 0xb82e785850266c370345245630424894df164b66e5c07a4da562f9b24cb56996 on block: 26048347 index: 2 multisig account id: 0xf91ceb7ea87f99d842d530f7df106e185a6a352a170857d9062e2368c4a1ee6d
2025-10-01T10:07:02.967Z <BlockDispatcherService> ERROR undefined Error: Failed to enqueue fetched block to process
Cause: Error: Operation not found for call hash: 0xb82e785850266c370345245630424894df164b66e5c07a4da562f9b24cb56996 on block: 26048347 index: 2 multisig account id: 0xf91ceb7ea87f99d842d530f7df106e185a6a352a170857d9062e2368c4a1ee6d
```

That happened due to ah migration, in execute event contains block from relaychain:
https://assethub-westend.subscan.io/extrinsic/11720095-2
Initiation block:
https://assethub-westend.subscan.io/block/11720048?tab=event

Fix based on approach that there is shouldn't be multiple pending transaction for one multisig address with the same call_hash


Tested by:
<img width="1854" height="928" alt="Screenshot 2025-10-01 at 18 53 23" src="https://github.com/user-attachments/assets/033e9c6b-3752-4dee-8a89-07f5faa3b0d4" />

