### PR TITLE
fix: use event payload at/extrinsicIndex for pure-proxy derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ Thumbs.db
 
 .data
 .eslintcache
+
+.claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -667,6 +667,34 @@ Note: from the `Option<MultiLocation>` boundary onward, the type evolves (xcm v3
 
 ---
 
+### 14. "Who X is not the pure account …" on Asset Hub Blocks (`createPure(when=Some(...))`)
+
+**Symptoms:**
+- Indexer loops on a specific AH block with `Error: Who 0x… is not the pure account 0x… or the pure account relay parent 0x…`.
+- Throw originates at `src/utils/pureAccountCalculation.ts` (`findPureBlockNumber`).
+- Affects mostly Polkadot/Kusama/Westend Asset Hub during/after the active relay→AH migration window.
+
+**Root cause:** The substrate proxy pallet's `pure_account(who, proxy_type, index, maybe_when)` derivation accepts an optional `maybe_when = Some((historic_block, historic_ext_idx))`. AH users recreate their relay-chain pure proxies on AH by calling `proxy.createPure(..., when = Some((original_relay_block, original_ext_idx)))`, so the runtime hashes the *historic relay* `(height, ext_idx)` into the entropy, not the AH envelope. The runtime exposes those values in event data fields `at` (data[4]) and `extrinsic_index` (data[5]). Older `extractPureProxyEventData` ignored both fields and pulled `blockNumber` / `extrinsicIndex` from the AH envelope (`event.block.block.header.number`, `event.extrinsic.idx`) — for legacy `createPure` without `when` they coincide; for migration-era `createPure(when=Some(...))` they diverge, derivation fails, and `findPureBlockNumber` throws.
+
+**Entry points:**
+- `src/utils/extractPureProxyEventData.ts` — must prefer payload `at` / `extrinsic_index` over envelope.
+- `src/utils/pureAccountCalculation.ts` → `findPureBlockNumber()` — assertion site.
+
+**How to diagnose:**
+1. Pull the offending block over RPC, find the `proxy.PureCreated` event, dump `event.toHuman()`. If `data.at` differs from the block's own number — this case.
+2. Quick DB check (substitute target chain genesis as `chain_id`):
+   ```sql
+   SELECT count(*) FROM app.proxieds
+   WHERE chain_id = '0x68d5…' AND is_pure_proxy = true AND block_number > 20000000;
+   ```
+   Non-zero count on an AH chain (current height ≪ 20M) indicates `createPure(when=...)` flow is live and the fix is needed.
+
+**Fix:** In `extractPureProxyEventData`, read `data.at(4)` / `data.at(5)` first and only fall back to `eventParser.blockNumber(event)` / `eventParser.extrinsicIndex(event)` when those fields are absent (older `AnonymousCreated` runtimes). Covered by test `src/test/polkadot-asset-hub/pureProxyEventHandler-when.test.ts` (block 15,503,985).
+
+**Related but distinct:** §4 is the same family of "computed pure ≠ on-chain pure" symptoms; that section covers the parachain-relay-parent fallback. §14 is the migration-era `maybe_when` override which neither the parachain block nor the relay-parent block can reproduce.
+
+---
+
 ## Database Operations (Per-Network Wipe)
 
 This section documents how to wipe data for **one chain only** in a shared multichain database.

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,22 @@
 # Postgres test container which is named so the trap-based cleanup can find
 # and remove it deterministically even if the test fails.
 #
+# Workspace isolation:
+#   - Source tree mounted READ-ONLY at /src.
+#   - All work happens inside a single named Podman volume mounted at /work
+#     (volume name: $(WORKSPACE_VOLUME)). This is the container's own
+#     filesystem space — never visible on the host, never creates stub
+#     directories under the project root.
+#   - On every build the source is rsynced from /src → /work (excluding
+#     generated dirs that yarn populates inside the volume). Build and
+#     test containers share the same volume so test sees what build wrote.
+#   - `podman-clean` deletes the volume; all artifacts vanish with it.
+#
 # Quick start:
-#   make podman-build                          # yarn install + codegen + build inside Node 24 podman
-#   make podman-test                           # build pg image, spin up pg + subql-node, run tests, tear down
+#   make podman-build                          # rsync source + yarn install + codegen + build, all in /work
+#   make podman-test                           # build pg image, spin up pg + subql-node, run tests against /work
 #   make podman-test CHAIN=kusama-asset-hub
-#   make podman-clean                          # nuke any leftover containers / networks / locally built test images
+#   make podman-clean                          # remove containers / network / locally built pg image / workspace volume
 
 SHELL        := /usr/bin/env bash
 .SHELLFLAGS  := -eu -o pipefail -c
@@ -27,10 +38,11 @@ NODE_IMAGE       := docker.io/library/node:24-alpine
 SUBQL_NODE_IMAGE := docker.io/subquerynetwork/subql-node-substrate:v5.6.0
 PG_TEST_IMAGE    := localhost/subql-pg-test:latest
 
-# Stable container / network names so `make podman-clean` is deterministic.
-PG_NAME  := subql-pg-test
-SQ_NAME  := subql-node-test
-NET_NAME := subql-test-net
+# Stable container / network / volume names so `make podman-clean` is deterministic.
+PG_NAME           := subql-pg-test
+SQ_NAME           := subql-node-test
+NET_NAME          := subql-test-net
+WORKSPACE_VOLUME  := subql-workspace
 
 # Target chain for tests. Override on CLI: `make podman-test CHAIN=kusama-asset-hub`.
 CHAIN        ?= polkadot-asset-hub
@@ -39,41 +51,60 @@ TEST_DIR     := src/test/$(CHAIN)
 
 PROJECT_ROOT := $(shell pwd)
 
-# Common podman invocation for the Node build container. No --userns=keep-id:
-# under rootless podman, root inside the container maps to the host user, so
-# files end up owned by the user on the host AND corepack can write into
-# /usr/local/bin inside the container. With --userns=keep-id, corepack fails
-# with EACCES.
+# rsync excludes — generated dirs that yarn / codegen / tsc populate inside
+# the workspace volume. `--exclude` protects matching paths from both copy
+# and `--delete`, so the volume's node_modules etc. survive across builds.
+# `.git` excluded because it's large and irrelevant to subql-node. `.claude`
+# excluded because it's editor/agent state.
+RSYNC_EXCLUDES := \
+	--exclude=node_modules \
+	--exclude=dist \
+	--exclude=.yarn \
+	--exclude=src/types \
+	--exclude=.git \
+	--exclude=.claude
+
+# Common podman invocation for the Node build container. Source mounted
+# read-only, workspace mounted from named volume. No --userns=keep-id:
+# under rootless podman, root inside maps to host user, so volume content
+# ends up correctly owned AND corepack can write into /usr/local/bin inside
+# the image. With --userns=keep-id, corepack fails with EACCES.
 PODMAN_NODE_RUN := podman run --rm \
-	-v "$(PROJECT_ROOT):/app:Z" \
-	-w /app \
+	-v "$(PROJECT_ROOT):/src:ro,Z" \
+	-v $(WORKSPACE_VOLUME):/work \
+	-w /work \
 	$(NODE_IMAGE) \
 	sh -c
 
+# Prelude that prepares /work: install rsync (busybox doesn't ship it),
+# mirror source into /work skipping volume-managed dirs.
+SYNC_SOURCE := apk add --no-cache rsync >/dev/null && rsync -a --delete $(RSYNC_EXCLUDES) /src/ /work/
+
 .PHONY: help \
 	podman-all podman-build podman-install podman-codegen podman-compile \
-	podman-pg-image podman-test podman-clean
+	podman-pg-image podman-test podman-clean \
+	clean-host-artifacts
 
 help: ## Show available targets
-	@awk 'BEGIN { FS = ":.*?## " } /^[a-zA-Z_-]+:.*?## / { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN { FS = ":.*?## " } /^[a-zA-Z_-]+:.*?## / { printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 podman-all: podman-build podman-test ## Build then test (full CI parity)
 
 # ---------------------------------------------------------------------------
-# Build (Node 24 container, --rm)
+# Build (Node 24 container, --rm; everything inside workspace volume)
 # ---------------------------------------------------------------------------
 
-podman-install: ## yarn install --immutable
-	$(PODMAN_NODE_RUN) 'corepack enable && yarn install --immutable'
+podman-install: ## rsync source into /work + yarn install --immutable
+	$(PODMAN_NODE_RUN) '$(SYNC_SOURCE) && corepack enable && yarn install --immutable'
 
-podman-codegen: ## yarn codegen
-	$(PODMAN_NODE_RUN) 'corepack enable && yarn codegen'
+podman-codegen: ## rsync source into /work + yarn codegen
+	$(PODMAN_NODE_RUN) '$(SYNC_SOURCE) && corepack enable && yarn codegen'
 
-podman-compile: ## yarn build
-	$(PODMAN_NODE_RUN) 'corepack enable && yarn build'
+podman-compile: ## rsync source into /work + yarn build
+	$(PODMAN_NODE_RUN) '$(SYNC_SOURCE) && corepack enable && yarn build'
 
-podman-build: ## install + codegen + build in one container shell
-	$(PODMAN_NODE_RUN) 'corepack enable && yarn install --immutable && yarn codegen && yarn build'
+podman-build: ## rsync source into /work + install + codegen + build in one container shell
+	$(PODMAN_NODE_RUN) '$(SYNC_SOURCE) && corepack enable && yarn install --immutable && yarn codegen && yarn build'
 
 # ---------------------------------------------------------------------------
 # Test (Postgres + subql-node containers, trap-based cleanup)
@@ -82,10 +113,13 @@ podman-build: ## install + codegen + build in one container shell
 podman-pg-image: ## Build the local Postgres test image from docker/pg-Dockerfile
 	podman build -t $(PG_TEST_IMAGE) -f docker/pg-Dockerfile .
 
-podman-test: podman-pg-image ## Run subql-node tests for $(CHAIN). Requires dist/ — run `make podman-build` first if missing.
+podman-test: podman-pg-image ## Run subql-node tests for $(CHAIN) against the workspace volume. Run `make podman-build` first.
 	@test -f "$(PROJECT_FILE)" || { echo "Project manifest not found: $(PROJECT_FILE)" >&2; exit 1; }
 	@test -d "$(TEST_DIR)"     || { echo "Test directory not found: $(TEST_DIR)" >&2; exit 1; }
-	@test -d "dist"            || { echo "dist/ not found — run 'make podman-build' first" >&2; exit 1; }
+	@if ! podman volume exists $(WORKSPACE_VOLUME) >/dev/null 2>&1; then \
+	  echo "workspace volume ($(WORKSPACE_VOLUME)) not found — run 'make podman-build' first" >&2; \
+	  exit 1; \
+	fi
 	@set -e ; \
 	cleanup() { \
 	  echo "=== cleanup ===" ; \
@@ -113,15 +147,15 @@ podman-test: podman-pg-image ## Run subql-node tests for $(CHAIN). Requires dist
 	podman run --rm --name $(SQ_NAME) --network $(NET_NAME) \
 	  -e DB_USER=postgres -e DB_PASS=postgres -e DB_DATABASE=postgres \
 	  -e DB_HOST=$(PG_NAME) -e DB_PORT=5432 \
-	  -v "$(PROJECT_ROOT):/app:Z" -w /app \
+	  -v $(WORKSPACE_VOLUME):/work -w /work \
 	  $(SUBQL_NODE_IMAGE) \
-	  test -f=/app/$(PROJECT_FILE) --db-schema=test
+	  test -f=/work/$(PROJECT_FILE) --db-schema=test
 
 # ---------------------------------------------------------------------------
 # Cleanup — idempotent, safe to run anytime
 # ---------------------------------------------------------------------------
 
-podman-clean: ## Remove leftover project containers, the test network, and the locally built pg image
+podman-clean: ## Remove leftover project containers, network, locally-built pg image, and the workspace volume
 	@echo "=== containers ==="
 	@for n in $(PG_NAME) $(SQ_NAME); do \
 	  if podman container exists $$n >/dev/null 2>&1; then \
@@ -142,3 +176,14 @@ podman-clean: ## Remove leftover project containers, the test network, and the l
 	else \
 	  echo "  (skip) $(PG_TEST_IMAGE) — not present" ; \
 	fi
+	@echo "=== volume ==="
+	@if podman volume exists $(WORKSPACE_VOLUME) >/dev/null 2>&1; then \
+	  podman volume rm $(WORKSPACE_VOLUME) >/dev/null && echo "  removed $(WORKSPACE_VOLUME)" ; \
+	else \
+	  echo "  (skip) $(WORKSPACE_VOLUME) — not present" ; \
+	fi
+
+clean-host-artifacts: ## One-time host cleanup: rm node_modules/, dist/, src/types/, .yarn/ if left over from earlier builds (no podman, plain rm).
+	@for d in node_modules dist src/types .yarn; do \
+	  if [ -e "$$d" ]; then rm -rf "$$d" && echo "  removed $$d" ; else echo "  (skip) $$d — not present" ; fi ; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,144 @@
+# Build / test orchestration for subquery-accounts.
+#
+# All current tasks run inside rootless Podman containers and are prefixed
+# `podman-*` to leave the unprefixed namespace free for future non-podman
+# tasks (e.g. host-side helpers, lint runners, formatters).
+#
+# Policy: no node / yarn / subql-node runs on the host. Everything runs in
+# rootless Podman containers that self-remove (`--rm`) after use, except the
+# Postgres test container which is named so the trap-based cleanup can find
+# and remove it deterministically even if the test fails.
+#
+# Quick start:
+#   make podman-build                          # yarn install + codegen + build inside Node 24 podman
+#   make podman-test                           # build pg image, spin up pg + subql-node, run tests, tear down
+#   make podman-test CHAIN=kusama-asset-hub
+#   make podman-clean                          # nuke any leftover containers / networks / locally built test images
+
+SHELL        := /usr/bin/env bash
+.SHELLFLAGS  := -eu -o pipefail -c
+.DEFAULT_GOAL := help
+
+# Images — pinned to match CI.
+#   .github/workflows/pr.yml         uses node 24
+#   docker-compose-test.yml          uses subql-node v5.6.0
+#   docker/pg-Dockerfile             builds Postgres 16 alpine + btree_gist
+NODE_IMAGE       := docker.io/library/node:24-alpine
+SUBQL_NODE_IMAGE := docker.io/subquerynetwork/subql-node-substrate:v5.6.0
+PG_TEST_IMAGE    := localhost/subql-pg-test:latest
+
+# Stable container / network names so `make podman-clean` is deterministic.
+PG_NAME  := subql-pg-test
+SQ_NAME  := subql-node-test
+NET_NAME := subql-test-net
+
+# Target chain for tests. Override on CLI: `make podman-test CHAIN=kusama-asset-hub`.
+CHAIN        ?= polkadot-asset-hub
+PROJECT_FILE := project-$(CHAIN).yaml
+TEST_DIR     := src/test/$(CHAIN)
+
+PROJECT_ROOT := $(shell pwd)
+
+# Common podman invocation for the Node build container. No --userns=keep-id:
+# under rootless podman, root inside the container maps to the host user, so
+# files end up owned by the user on the host AND corepack can write into
+# /usr/local/bin inside the container. With --userns=keep-id, corepack fails
+# with EACCES.
+PODMAN_NODE_RUN := podman run --rm \
+	-v "$(PROJECT_ROOT):/app:Z" \
+	-w /app \
+	$(NODE_IMAGE) \
+	sh -c
+
+.PHONY: help \
+	podman-all podman-build podman-install podman-codegen podman-compile \
+	podman-pg-image podman-test podman-clean
+
+help: ## Show available targets
+	@awk 'BEGIN { FS = ":.*?## " } /^[a-zA-Z_-]+:.*?## / { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+podman-all: podman-build podman-test ## Build then test (full CI parity)
+
+# ---------------------------------------------------------------------------
+# Build (Node 24 container, --rm)
+# ---------------------------------------------------------------------------
+
+podman-install: ## yarn install --immutable
+	$(PODMAN_NODE_RUN) 'corepack enable && yarn install --immutable'
+
+podman-codegen: ## yarn codegen
+	$(PODMAN_NODE_RUN) 'corepack enable && yarn codegen'
+
+podman-compile: ## yarn build
+	$(PODMAN_NODE_RUN) 'corepack enable && yarn build'
+
+podman-build: ## install + codegen + build in one container shell
+	$(PODMAN_NODE_RUN) 'corepack enable && yarn install --immutable && yarn codegen && yarn build'
+
+# ---------------------------------------------------------------------------
+# Test (Postgres + subql-node containers, trap-based cleanup)
+# ---------------------------------------------------------------------------
+
+podman-pg-image: ## Build the local Postgres test image from docker/pg-Dockerfile
+	podman build -t $(PG_TEST_IMAGE) -f docker/pg-Dockerfile .
+
+podman-test: podman-pg-image ## Run subql-node tests for $(CHAIN). Requires dist/ — run `make podman-build` first if missing.
+	@test -f "$(PROJECT_FILE)" || { echo "Project manifest not found: $(PROJECT_FILE)" >&2; exit 1; }
+	@test -d "$(TEST_DIR)"     || { echo "Test directory not found: $(TEST_DIR)" >&2; exit 1; }
+	@test -d "dist"            || { echo "dist/ not found — run 'make podman-build' first" >&2; exit 1; }
+	@set -e ; \
+	cleanup() { \
+	  echo "=== cleanup ===" ; \
+	  podman rm -f $(PG_NAME) >/dev/null 2>&1 || true ; \
+	  podman rm -f $(SQ_NAME) >/dev/null 2>&1 || true ; \
+	  podman network rm $(NET_NAME) >/dev/null 2>&1 || true ; \
+	} ; \
+	trap cleanup EXIT INT TERM ; \
+	echo "=== ensuring clean slate ===" ; \
+	podman rm -f $(PG_NAME) >/dev/null 2>&1 || true ; \
+	podman rm -f $(SQ_NAME) >/dev/null 2>&1 || true ; \
+	podman network rm $(NET_NAME) >/dev/null 2>&1 || true ; \
+	echo "=== creating network $(NET_NAME) ===" ; \
+	podman network create $(NET_NAME) >/dev/null ; \
+	echo "=== starting postgres ($(PG_NAME)) ===" ; \
+	podman run -d --name $(PG_NAME) --network $(NET_NAME) \
+	  -e POSTGRES_PASSWORD=postgres \
+	  $(PG_TEST_IMAGE) >/dev/null ; \
+	echo "=== waiting for postgres ===" ; \
+	for i in $$(seq 1 30); do \
+	  podman exec $(PG_NAME) pg_isready -U postgres >/dev/null 2>&1 && break ; \
+	  sleep 2 ; \
+	done ; \
+	echo "=== running subql-node test (chain=$(CHAIN)) ===" ; \
+	podman run --rm --name $(SQ_NAME) --network $(NET_NAME) \
+	  -e DB_USER=postgres -e DB_PASS=postgres -e DB_DATABASE=postgres \
+	  -e DB_HOST=$(PG_NAME) -e DB_PORT=5432 \
+	  -v "$(PROJECT_ROOT):/app:Z" -w /app \
+	  $(SUBQL_NODE_IMAGE) \
+	  test -f=/app/$(PROJECT_FILE) --db-schema=test
+
+# ---------------------------------------------------------------------------
+# Cleanup — idempotent, safe to run anytime
+# ---------------------------------------------------------------------------
+
+podman-clean: ## Remove leftover project containers, the test network, and the locally built pg image
+	@echo "=== containers ==="
+	@for n in $(PG_NAME) $(SQ_NAME); do \
+	  if podman container exists $$n >/dev/null 2>&1; then \
+	    podman rm -f $$n >/dev/null && echo "  removed $$n" ; \
+	  else \
+	    echo "  (skip) $$n — not present" ; \
+	  fi ; \
+	done
+	@echo "=== network ==="
+	@if podman network exists $(NET_NAME) >/dev/null 2>&1; then \
+	  podman network rm $(NET_NAME) >/dev/null && echo "  removed $(NET_NAME)" ; \
+	else \
+	  echo "  (skip) $(NET_NAME) — not present" ; \
+	fi
+	@echo "=== image ==="
+	@if podman image exists $(PG_TEST_IMAGE) >/dev/null 2>&1; then \
+	  podman image rm $(PG_TEST_IMAGE) >/dev/null && echo "  removed $(PG_TEST_IMAGE)" ; \
+	else \
+	  echo "  (skip) $(PG_TEST_IMAGE) — not present" ; \
+	fi

--- a/src/test/polkadot-asset-hub/pureProxyEventHandler-when.test.ts
+++ b/src/test/polkadot-asset-hub/pureProxyEventHandler-when.test.ts
@@ -1,0 +1,68 @@
+import { subqlTest } from "@subql/testing";
+import { Proxied, PureProxy } from "../../types";
+
+// Polkadot Asset Hub block 15,503,985, extrinsic 2 — proxy.createPure with an
+// explicit `when = Some((historic_relay_block, historic_ext_idx))`. This is the
+// canonical migration scenario: an Asset Hub user re-creates on AH the same
+// pure proxy they had on Polkadot relay, so the AH-side derivation has to use
+// the relay's original `(block_number, extrinsic_index)` rather than the AH
+// envelope. The runtime exposes those values in event data fields `at` (data[4])
+// and `extrinsicIndex` (data[5]); `extractPureProxyEventData` must read from
+// the payload, not from `event.block.block.header.number` / `event.extrinsic.idx`.
+//
+// Event payload (from RPC):
+//   pure:                 15aFQvvt8j2ZCvMEjnUSz7s1nxt1yA1znBN8yUFo1SCr4YMk
+//                       = 0xca4c8c9aa817020d515f77e46d60c74fdc7ea74244bba937e06a6a8abed5c746
+//   who (spawner):        13TRAXTALwNp5vApqwiE74fg8G8ypMyaF9TxRfs4RwrCwxUE
+//                       = 0x6c9e3102dd2c24274667d416e07570ebce6f20ab80ee3fc9917bf4a7568b8fd2
+//   proxyType:            Any
+//   disambiguationIndex:  1337         (data[3] — also exercises Number(toString())
+//                                       vs the legacy parseInt(toHuman())="1,337"→1 bug)
+//   at:                   31,147,672   (data[4] — relay-chain block; must end up in
+//                                       PureProxy.entropyBlockNumber / Proxied.blockNumber)
+//   extrinsicIndex:       2            (data[5] — must end up in *.extrinsicIndex)
+//
+// Pre-fix behaviour: extractPureProxyEventData wrote envelope values
+// (blockNumber=15503985, extrinsicIndex=2) into entities, and findPureBlockNumber
+// threw `Who 0x6c9e… is not the pure account …`, looping the indexer.
+//
+// https://assethub-polkadot.subscan.io/block/15503985
+
+const CHAIN_ID = "0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f";
+const PURE = "0xca4c8c9aa817020d515f77e46d60c74fdc7ea74244bba937e06a6a8abed5c746";
+const SPAWNER = "0x6c9e3102dd2c24274667d416e07570ebce6f20ab80ee3fc9917bf4a7568b8fd2";
+
+const DERIVATION_BLOCK = 31147672; // relay-chain block from payload `at` — NOT 15503985
+const DERIVATION_EXT_IDX = 2;
+const DISAMBIGUATION_INDEX = 1337;
+
+subqlTest(
+  "PureCreated with explicit `when`: uses payload at/extrinsicIndex for derivation",
+  15503985,
+  [],
+  [
+    PureProxy.create({
+      id: `${CHAIN_ID}-${PURE}`,
+      chainId: CHAIN_ID,
+      accountId: PURE,
+      spawner: SPAWNER,
+      disambiguationIndex: DISAMBIGUATION_INDEX,
+      entropyBlockNumber: DERIVATION_BLOCK,
+      extrinsicIndex: DERIVATION_EXT_IDX,
+    }),
+    Proxied.create({
+      id: `${CHAIN_ID}-${PURE}-${SPAWNER}-Any-0`,
+      chainId: CHAIN_ID,
+      type: "Any",
+      proxyAccountId: SPAWNER,
+      accountId: PURE,
+      delay: 0,
+      blockNumber: DERIVATION_BLOCK,
+      extrinsicIndex: DERIVATION_EXT_IDX,
+      isPureProxy: true,
+      disambiguationIndex: DISAMBIGUATION_INDEX,
+      spawner: SPAWNER,
+    }),
+  ],
+  "handlePureProxyEvent",
+);

--- a/src/utils/extractPureProxyEventData.ts
+++ b/src/utils/extractPureProxyEventData.ts
@@ -30,6 +30,25 @@ export function extractPureProxyEventData(event: SubstrateEvent): PureProxyEvent
   const type = data.at(2);
   const disambiguationIndex = Number(data.at(3)?.toString());
 
+  // Modern proxy.PureCreated events carry the derivation parameters (`at`,
+  // `extrinsicIndex`) in the event payload itself. They reflect whatever the
+  // runtime actually passed to `pure_account(..., maybe_when)`. When a user
+  // calls `proxy.createPure` with an explicit `when = Some((historic_block,
+  // historic_ext_idx))` — the canonical case being Asset Hub users re-creating
+  // their relay-chain pure proxies on AH — these payload fields are the only
+  // way to reproduce the on-chain pure address. The block envelope (header
+  // block number / extrinsic.idx) describes WHEN the call was dispatched, not
+  // WHAT inputs went into the entropy.
+  //
+  // For older runtimes that emit `AnonymousCreated` with only 4 fields, or any
+  // chain whose runtime does not include these fields, `data.at(4)` is undefined
+  // and we fall back to the envelope — matches the previous (legacy) behaviour.
+  const atField = data.at(4);
+  const extrinsicIndexField = data.at(5);
+
+  const blockNumber = atField !== undefined ? Number(atField.toString()) : eventParser.blockNumber(event);
+  const extrinsicIndex = extrinsicIndexField !== undefined ? Number(extrinsicIndexField.toString()) : eventParser.extrinsicIndex(event);
+
   if (!who) {
     logger.error(`Invalid proxyAccountId: ${JSON.stringify(who)}`);
     return null;
@@ -50,13 +69,23 @@ export function extractPureProxyEventData(event: SubstrateEvent): PureProxyEvent
     return null;
   }
 
+  if (!Number.isFinite(blockNumber)) {
+    logger.error(`Invalid blockNumber from event payload: ${JSON.stringify(atField?.toString())}`);
+    return null;
+  }
+
+  if (!Number.isFinite(extrinsicIndex)) {
+    logger.error(`Invalid extrinsicIndex from event payload: ${JSON.stringify(extrinsicIndexField?.toString())}`);
+    return null;
+  }
+
   return {
     pure: u8aToHex(decodeAddress(pure)),
     spawner: u8aToHex(decodeAddress(who)),
     type,
     delay: 0,
     disambiguationIndex,
-    blockNumber: eventParser.blockNumber(event),
-    extrinsicIndex: eventParser.extrinsicIndex(event),
+    blockNumber,
+    extrinsicIndex,
   };
 }


### PR DESCRIPTION
## Summary

- `proxy.PureCreated` events from `proxy.createPure(..., when = Some((relay_block, ext_idx)))` — most commonly emitted by Asset Hub users re-creating their relay-chain pure proxies on AH — encode the derivation inputs (`at`, `extrinsicIndex`) in the **event payload** at `data[4]` / `data[5]`, not in the block envelope. Substrate's `pure_account(..., maybe_when)` hashes the historic relay block height into the entropy, so the only way to reproduce the on-chain pure address is to read those payload fields.
- `extractPureProxyEventData` previously pulled `blockNumber` / `extrinsicIndex` from `event.block.block.header.number` and `event.extrinsic.idx`. For legacy `createPure`-without-`when` both sources coincide and the bug went undetected for years. For migration-era `createPure`-with-`when` they diverge, `findPureBlockNumber` throws `Who … is not the pure account …`, and the indexer loops fatally — observed on **Polkadot Asset Hub block 15,503,985**.
- Read `data.at(4)` / `data.at(5)` first; fall back to the envelope only when those fields are absent (older runtimes / 4-field `AnonymousCreated`). Stricter validation via `Number.isFinite` on all numeric fields.
- AGENTS.md §14 in Troubleshooting documents the symptom, root cause, RPC + SQL diagnosis, and code entry points so the next person hitting a `pure_account` mismatch has a head start.
- Adds a local Makefile (`podman-build` / `podman-test` / `podman-clean`) that reproduces the CI flow in rootless Podman without running Node on the host — read-only source mount, single named workspace volume, zero host pollution.
