### PR TITLE
fix: harden multisig account derivation against sandbox crypto corruption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ src/
   utils/
     operations.ts               # generateOperationId, getDataFromEvent/Call, timestamp
     multisigHelpers.ts          # findExistingOperation, createMultisigEvent, isThreshold1
-    addressesDecode.ts          # createKeyMultiAddress, decodeAddress
+    addressesDecode.ts          # createKeyMultiAccountId, decodeAddress
+    cryptoIntegrity.ts          # assertCryptoIntegrity -- known-vector canary for derived ids
     pureAccountCalculation.ts   # calculatePureAccount, findPureBlockNumber
     extractProxyEventData.ts    # Proxy event data parsing
     extractPureProxyEventData.ts # Pure proxy event data parsing
@@ -118,7 +119,7 @@ Every network subscribes to the same set of call/event handlers for the `multisi
 |---|---|
 | **Kusama** | Multisig lived in the `utility` module before spec 2007 (block 2,704,203). Requires additional `utility.*` event/call handlers + lowered startBlock. See Kusama deep-dive below. |
 | **Polkadot, Kusama, Westend** | Handle `rcMigrator.AssetHubMigrationStarted` for migrating proxy data to Asset Hub |
-| **Moonbeam, Moonriver** | EVM-compatible chains. 20-byte addresses (Ethereum format). `createKeyMultiAddress` handles both formats |
+| **Moonbeam, Moonriver** | EVM-compatible chains. 20-byte addresses (Ethereum format). `createKeyMultiAccountId` handles both formats |
 | **Asset Hub chains** | Use custom chainTypes with `NovaAssetId` evolving across spec versions |
 | **Bittensor** | Custom types (`Balance` as u64), startBlock=1 |
 | **Avail** | Extensive DA-specific types, custom `CheckAppId` signed extension |
@@ -565,9 +566,9 @@ Additionally, on old `MultisigExecuted`, field index 3 is `DispatchResult`, not 
 **Symptom:** Incorrect multisig addresses or errors when creating AccountMultisig records.
 
 **Entry point:**
-- `src/utils/addressesDecode.ts` -> `createKeyMultiAddress()`, `decodeAddress()`
+- `src/utils/addressesDecode.ts` -> `createKeyMultiAccountId()`, `decodeAddress()`
 
-**Cause:** EVM chains use 20-byte addresses (Ethereum format) instead of 32-byte Substrate addresses. `createKeyMultiAddress` handles both formats, but any changes must account for both code paths.
+**Cause:** EVM chains use 20-byte addresses (Ethereum format) instead of 32-byte Substrate addresses. `createKeyMultiAccountId` handles both formats, but any changes must account for both code paths.
 
 ### 9. Type Errors After Updating @polkadot/* Dependencies
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Safety limit: batches with >10,000 calls/events are skipped (`context.stop()`).
 
 ```
 NewMultisig         -> creates MultisigOperation (status: pending)
-MultisigApproved    -> finds existing operation, adds MultisigEvent
+MultisigApproval    -> finds existing operation, adds MultisigEvent
 MultisigExecuted    -> finalizes (status: executed | error)
 MultisigCancelled   -> cancels (status: cancelled)
 ```

--- a/project-aleph-zero.yaml
+++ b/project-aleph-zero.yaml
@@ -159,7 +159,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-avail.yaml
+++ b/project-avail.yaml
@@ -159,7 +159,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-bittensor.yaml
+++ b/project-bittensor.yaml
@@ -158,7 +158,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-hydradx.yaml
+++ b/project-hydradx.yaml
@@ -157,7 +157,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-kusama-asset-hub.yaml
+++ b/project-kusama-asset-hub.yaml
@@ -159,7 +159,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-kusama-coretime.yaml
+++ b/project-kusama-coretime.yaml
@@ -156,7 +156,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-kusama-people-chain.yaml
+++ b/project-kusama-people-chain.yaml
@@ -158,7 +158,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-kusama.yaml
+++ b/project-kusama.yaml
@@ -199,7 +199,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-moonbeam.yaml
+++ b/project-moonbeam.yaml
@@ -171,7 +171,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-moonriver.yaml
+++ b/project-moonriver.yaml
@@ -171,7 +171,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-mythos.yaml
+++ b/project-mythos.yaml
@@ -160,7 +160,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-polkadot-asset-hub.yaml
+++ b/project-polkadot-asset-hub.yaml
@@ -159,7 +159,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-polkadot-collectives.yaml
+++ b/project-polkadot-collectives.yaml
@@ -157,7 +157,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-polkadot-coretime.yaml
+++ b/project-polkadot-coretime.yaml
@@ -157,7 +157,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-polkadot-people-chain.yaml
+++ b/project-polkadot-people-chain.yaml
@@ -157,7 +157,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-polkadot.yaml
+++ b/project-polkadot.yaml
@@ -181,7 +181,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
             success: true
             isSigned: true
 

--- a/project-rococo.yaml
+++ b/project-rococo.yaml
@@ -157,7 +157,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-testnet.yaml
+++ b/project-testnet.yaml
@@ -157,7 +157,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-westend-asset-hub.yaml
+++ b/project-westend-asset-hub.yaml
@@ -159,7 +159,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/project-westend.yaml
+++ b/project-westend.yaml
@@ -163,7 +163,7 @@ dataSources:
           kind: substrate/EventHandler
           filter:
             module: multisig
-            method: MultisigApproved
+            method: MultisigApproval
 
         - handler: handleMultisigExecutedEvent
           kind: substrate/EventHandler

--- a/src/mappings/handlers/multisigCallHandler.ts
+++ b/src/mappings/handlers/multisigCallHandler.ts
@@ -3,14 +3,17 @@ import { VisitedCall } from "subquery-call-visitor";
 import { MultisigArgs, MultisigThreshold1Args } from "../types";
 import { checkAndGetAccount } from "../../utils/checkAndGetAccount";
 import { checkAndGetAccountMultisig } from "../../utils/checkAndGetAccountMultisig";
-import { decodeAddress, createKeyMultiAddress } from "../../utils";
+import { decodeAddress, createKeyMultiAccountId } from "../../utils";
+import { assertCryptoIntegrity } from "../../utils/cryptoIntegrity";
 
 export const handleMultisigCall = async (call: VisitedCall): Promise<void> => {
+  assertCryptoIntegrity();
+
   const [threshold, otherSignatories] = extractThresholdAndOtherSignatories(call);
   const allSignatories = [...otherSignatories, call.origin];
 
   const signatoryAccounts = await Promise.all(allSignatories.map(addr => checkAndGetAccount(toAccountId(addr))));
-  const multisigAccount = await checkAndGetAccount(toAccountId(createKeyMultiAddress(allSignatories, threshold)), true, threshold);
+  const multisigAccount = await checkAndGetAccount(createKeyMultiAccountId(allSignatories, threshold), true, threshold);
   const accountMultisigs = await Promise.all(signatoryAccounts.map(member => checkAndGetAccountMultisig(multisigAccount.id, member.id)));
 
   await Promise.all(signatoryAccounts.map(member => member.save()));
@@ -22,10 +25,16 @@ function toAccountId(address: string): string {
   return u8aToHex(decodeAddress(address));
 }
 
-function validateThreshold(threshold: number): void {
-  if (threshold < 1) {
+// toHuman() renders u16 as a locale-formatted string ("4", or "1,024" past 999),
+// which BN would reject and the store would persist as a string.
+function normalizeThreshold(threshold: number | string): number {
+  const value = typeof threshold === "number" ? threshold : Number(String(threshold).replace(/,/g, ""));
+
+  if (!Number.isInteger(value) || value < 1) {
     throw new Error(`Invalid threshold: ${threshold}`);
   }
+
+  return value;
 }
 
 function extractThresholdAndOtherSignatories(call: VisitedCall): [number, string[]] {
@@ -40,7 +49,5 @@ function extractThresholdAndOtherSignatories(call: VisitedCall): [number, string
     args: { threshold, other_signatories },
   } = call.call.toHuman() as unknown as MultisigArgs;
 
-  validateThreshold(threshold);
-
-  return [threshold, other_signatories];
+  return [normalizeThreshold(threshold), other_signatories];
 }

--- a/src/mappings/handlers/multisigRemarkHandler.ts
+++ b/src/mappings/handlers/multisigRemarkHandler.ts
@@ -1,7 +1,8 @@
 import { SubstrateExtrinsic } from "@subql/types";
 import { checkAndGetAccount } from "../../utils/checkAndGetAccount";
 import { checkAndGetAccountMultisig } from "../../utils/checkAndGetAccountMultisig";
-import { decodeAddress, createKeyMultiAddress } from "../../utils";
+import { decodeAddress, createKeyMultiAccountId } from "../../utils";
+import { assertCryptoIntegrity } from "../../utils/cryptoIntegrity";
 import { u8aToHex } from "@polkadot/util";
 import { MultisigRemarkArgs } from "../types";
 import { validateAddress } from "../../utils/validateAddress";
@@ -65,9 +66,9 @@ async function handleMultisigRemarkCall(call: VisitedCall): Promise<void> {
 
   logger.info(`Signatories Accounts: ${JSON.stringify(allSignatoriesAccounts)}`);
 
-  const multisigAddress = createKeyMultiAddress(parsedArgs.signatories, parsedArgs.threshold);
+  assertCryptoIntegrity();
 
-  const multisigPubKey = u8aToHex(decodeAddress(multisigAddress));
+  const multisigPubKey = createKeyMultiAccountId(parsedArgs.signatories, parsedArgs.threshold);
 
   const multisigAccount = await checkAndGetAccount(multisigPubKey, true, parsedArgs.threshold);
 

--- a/src/test/polkadot-asset-hub/multisigCallHandler.test.ts
+++ b/src/test/polkadot-asset-hub/multisigCallHandler.test.ts
@@ -24,9 +24,7 @@ subqlTest(
       id: MULTISIG,
       accountId: MULTISIG,
       isMultisig: true,
-      // toHuman() emits substrate u16 as a string and the handler stores it verbatim;
-      // see extractThresholdAndOtherSignatories in multisigCallHandler.ts.
-      threshold: "2" as unknown as number,
+      threshold: 2,
     }),
     Account.create({
       id: SIGNATORY_1,

--- a/src/utils/addressesDecode.ts
+++ b/src/utils/addressesDecode.ts
@@ -56,25 +56,27 @@ export function encodeAddress(publicKey: Uint8Array | string, ss58Format?: numbe
 }
 
 /**
- * Derive a Substrate multisig account address from its signatories and threshold.
+ * Derive a multisig account id (hex) from its signatories and threshold.
  *
- * Functionally equivalent to @polkadot/util-crypto's `encodeMultiAddress`, but
+ * Functionally equivalent to @polkadot/util-crypto's `createKeyMulti`, but
  * provides our own MULTISIG_PREFIX (see above) instead of letting the library
- * compute it via stringToU8a — the only place in the chain that breaks under
- * the SubQuery sandbox.
+ * compute it via stringToU8a, and returns the raw account id without an SS58
+ * round-trip: SS58 encoding hashes a blake2 checksum through the same
+ * sandbox-fragile pipeline, producing addresses with invalid checksums that
+ * only survive because decodeAddress ignores them.
  *
  * @param who Array of SS58/EVM addresses or pre-decoded public keys
  * @param threshold Number of approvals required to dispatch a multisig call
- * @returns The multisig account address (SS58 for Substrate, 0x… for EVM)
+ * @returns The multisig account id as hex (32 bytes for Substrate, 20 for EVM)
  */
-export function createKeyMultiAddress(who: (string | Uint8Array)[], threshold: bigint | BN | number): string {
+export function createKeyMultiAccountId(who: (string | Uint8Array)[], threshold: bigint | BN | number): string {
   const decoded = who.map(addr => (typeof addr === "string" ? decodeAddress(addr) : addr));
   const blakeInput = u8aConcat(MULTISIG_PREFIX, compactToU8a(decoded.length), ...u8aSorted(decoded), bnToU8a(threshold as number, THRESHOLD_LE_OPTS));
   const multisigKey = blake2AsU8a(blakeInput);
 
   if (typeof who[0] === "string" && ETHEREUM_ADDRESS_REGEX.test(who[0].trim())) {
-    return encodeAddress(addressToEvm(multisigKey, false));
+    return u8aToHex(addressToEvm(multisigKey, false));
   }
 
-  return encodeAddress(multisigKey);
+  return u8aToHex(multisigKey);
 }

--- a/src/utils/cryptoIntegrity.ts
+++ b/src/utils/cryptoIntegrity.ts
@@ -1,0 +1,52 @@
+import { createKeyMultiAccountId } from "./addressesDecode";
+
+// Real 4-of-7 multisig from Polkadot Asset Hub block 6706950, extrinsic 2.
+// The NewMultisig event is the on-chain ground truth for the derived account id:
+// https://assethub-polkadot.subscan.io/extrinsic/6706950-2
+//
+// v2.5.0 derived 0x485f6f80…d373 from these exact inputs when running inside the
+// SubQuery sandbox (host-realm Uint8Array corruption inside util-crypto, see
+// MULTISIG_PREFIX in addressesDecode.ts) and silently indexed wrong multisig
+// accounts for months. This canary turns that failure mode into a hard crash on
+// the first derivation instead.
+const CANARY_SIGNATORIES = [
+  "0x0c691601793de060491dab143dfae19f5f6413d4ce4c363637e5ceacb2836a4e",
+  "0x18bd4fb6b90f5088bdc825c3d674bd72e705c6f1163e86f960eeb7969ab4833a",
+  "0x2055808c210d863dfc372ec85beafa8fd3a8ff497f8eaee401ef05bf27d3065b",
+  "0x42be75cb933073a967d8cb8c6c723028208a678c5a58f5e8f49a237eb33e1654",
+  "0x7cbcc6a855945d221338c68bec20f892c73ccb4fc9be838d8e525c225129a00a",
+  "0xe424b2ee4c8a8fb3334248367a7a7e5c2d236205368cd4aee4e8ae274fc45566",
+  "0xe43550c34b73d305a049fb155219ea2cc3dd7b3fe71f93658d7554ccd33db210",
+];
+const CANARY_THRESHOLD = 4;
+const CANARY_EXPECTED = "0x4e289015f60c88b9b1d1b58ba4110ed1e3e745b82101db274e1afba4b19eed63";
+
+let verified = false;
+
+/**
+ * Verify that address derivation produces a known-correct result in the current
+ * runtime before any derived account id is written to the store.
+ *
+ * The @polkadot byte/hash pipeline has repeatedly broken inside the SubQuery
+ * sandbox in environment-specific ways (#88, #90, #92) while staying perfectly
+ * healthy on the host — unit tests pass, the indexer keeps processing blocks,
+ * and garbage account ids land in the database unnoticed. Every handler that
+ * derives an account id must call this before saving; the check runs once per
+ * process and is a no-op afterwards.
+ *
+ * @throws Error if the derivation pipeline returns a wrong result
+ */
+export function assertCryptoIntegrity(): void {
+  if (verified) return;
+
+  const actual = createKeyMultiAccountId(CANARY_SIGNATORIES, CANARY_THRESHOLD);
+  if (actual !== CANARY_EXPECTED) {
+    throw new Error(
+      `Crypto integrity check failed: multisig derivation returned ${actual}, expected ${CANARY_EXPECTED}. ` +
+        "The @polkadot byte/hash pipeline is corrupted in this runtime (sandbox realm issue — " +
+        "see MULTISIG_PREFIX in addressesDecode.ts). Refusing to index derived account ids.",
+    );
+  }
+
+  verified = true;
+}


### PR DESCRIPTION
## Context

v2.5.0 (currently deployed on `accounts-prod-2`) silently indexed wrong multisig account ids: inside the SubQuery sandbox, `createKeyMultiAddress` → `encodeMultiAddress` corrupted the derivation payload (host-realm `Uint8Array` failing `isU8a`, see the `MULTISIG_PREFIX` comment), so `Multisig`/`AccountMultisig` entities were created under garbage ids while `MultisigOperation`s (event-derived) stayed correct. Live impact measured against Nova Spektr's account set: 116 multisigs missing / 165 phantoms on prod-2 vs prod-1; Spektr's discovery (`accounts → multisigs` join) loses those wallets.

Repro (PAH block 6706950, `approveAsMulti` 4-of-7): on-chain `NewMultisig` says `0x4e289015…eed63`, v2.5.0 in-sandbox derived `0x485f6f80…d373` — exactly the phantom id present in prod-2. The same inputs through the same node_modules on the host derive correctly, and the sandbox-produced SS58 string carries an **invalid checksum** — two independent blake2 computations wrong in-sandbox, healthy on host. #90 already fixed the derivation itself (verified: same block now yields `0x4e28…` + 7 joins); this PR hardens the remaining gaps so this class of bug can't silently corrupt data again.

## Changes

- **`assertCryptoIntegrity()` canary** (new `src/utils/cryptoIntegrity.ts`): derives the real 4-of-7 PAH multisig from block 6706950 and compares against the on-chain id; called before any derived account id is written (`handleMultisigCall`, remark handler). Runs once per process. With this in v2.5.0, prod-2 would have crashed on the first block instead of silently indexing garbage for months.
- **`createKeyMultiAddress` → `createKeyMultiAccountId`**: returns the account id as hex directly, dropping the SS58 round-trip — SS58 encoding hashes a blake2 checksum through the same sandbox-fragile pipeline, producing addresses with invalid checksums that only survived because `decodeAddress` ignores them.
- **`normalizeThreshold`**: `toHuman()` renders u16 as a locale string (`"4"`, `"1,024"` past 999) — the store persisted it as a string (see the removed test workaround) and BN would reject the comma form. Now parsed and validated as an integer.

## Verification

- Local subql-node v6.4.6 run on PAH from block 6706900: multisig `0x4e289015…eed63` created with 7 signatory joins and integer `threshold = 4`; canary passes in-sandbox, no indexing errors.
- `scripts/run-tests.sh polkadot-asset-hub`: 4/4 tests pass (threshold expectation updated to integer `2`).

## Deployment note

The derivation fix (#90) + this hardening are **not in any release** — prod-2 still runs broken v2.5.0 and needs a release + full reindex (or `accountMultisigs`/`accounts` backfill) before it can serve Nova Spektr traffic.